### PR TITLE
ci: add GitHub Actions workflow 'test'

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname "$0")/..
+
+run_sim() {
+  echo "::group::Test $1"
+  cd "$1"/sim/vhdl
+  $MAKE sim
+  cd ../../..
+  echo '::endgroup::'
+}
+
+for item in aes cbcdes cbcmac_des cbctdes des tdes; do
+  run_sim $item
+done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: 'test'
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+
+  lin:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: |
+        sudo apt update -qq
+        sudo apt install -y libssl-dev
+
+    - uses: ghdl/setup-ghdl-ci@master
+      with:
+        backend: llvm
+
+    - run: ./.github/test.sh
+      env:
+        MAKE: make
+
+
+  win:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >
+          mingw-w64-x86_64-make
+          mingw-w64-x86_64-ghdl-llvm
+          mingw-w64-x86_64-openssl
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - run: ./.github/test.sh
+      env:
+        MAKE: mingw32-make

--- a/aes/sim/vhdl/Makefile
+++ b/aes/sim/vhdl/Makefile
@@ -20,9 +20,10 @@
 
 RTL_SRC := \
   ../../rtl/vhdl/aes_pkg.vhd \
-  ../../rtl/vhdl/aes.vhd     \
   ../../rtl/vhdl/aes_enc.vhd \
-  ../../rtl/vhdl/aes_dec.vhd
+  ../../rtl/vhdl/aes_dec.vhd \
+  ../../rtl/vhdl/aes.vhd
+
 
 SIM_SRC   := tb_aes.vhd
 C_SRC     := tb_aes.c

--- a/aes/sim/vhdl/Makefile
+++ b/aes/sim/vhdl/Makefile
@@ -73,7 +73,7 @@ tb_aes: ${RTL_SRC} ${SIM_SRC} ${C_SRC} osvvm/OsvvmContext.o | work
 	@echo "Analyze testbench & design ..."
 	ghdl -a --std=$(VHD_STD) -fpsl --workdir=work -P=osvvm ${RTL_SRC} ${SIM_SRC}
 	@echo "Elaborate testbench & design ..."
-	ghdl -e --std=$(VHD_STD) -fpsl --workdir=work -P=osvvm -Wl,-lcrypto -Wl,-lssl -Wl,$@.c $@
+	ghdl -e --std=$(VHD_STD) -fpsl --workdir=work -P=osvvm -Wl,$@.c -Wl,-lcrypto -Wl,-lssl $@
 
 
 tb_aes.ghw: tb_aes


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for running the simulations on Ubuntu and Windows. While running `aes` on MSYS2 (MINGW64) using GHDL from official repositories, I had to fix the order of VHDL sources. Apart from that, I had to fix the args for compilation, so that linker args are at the end.